### PR TITLE
Rewrite spec-validate CLI

### DIFF
--- a/scripts/spec-validate.sh
+++ b/scripts/spec-validate.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 usage() {
   cat <<USAGE
-Usage: $0 [--json] [--diff <file|->] spec_file
-Validate a spec against the core validator spec using OpenAI or Anthropic APIs.
+Usage: $(basename "$0") [--json] [--diff <file|->] SPEC_FILE
+Validate a specification using the Spec Validator reference spec.
 USAGE
   exit 1
 }
@@ -30,7 +30,7 @@ while [[ $# -gt 0 ]]; do
       shift
       break
       ;;
-    -* )
+    -*)
       echo "Unknown option: $1" >&2
       usage
       ;;
@@ -56,7 +56,6 @@ case "$spec_file" in
     ;;
 esac
 
-# Determine API provider
 if [[ -n "${OPENAI_API_KEY:-}" ]]; then
   provider="openai"
   api_key="$OPENAI_API_KEY"
@@ -77,77 +76,92 @@ if [[ -n "$diff_input" ]]; then
   else
     diff_content="$(cat "$diff_input")"
   fi
+  diff_content=$(echo "$diff_content" | awk -v file="$spec_file" '
+    /^diff --git/ {
+      path=$0;
+      sub(/^diff --git a\//, "", path);
+      sub(/ b\/.*/, "", path);
+      keep=(path==file);
+      next
+    }
+    keep
+  ')
 else
   diff_content=""
 fi
 
 system_prompt="$(bash "$(dirname "$0")/../promptTemplate-GPT.sh")"
 
-# Compose user message
 user_message="REFERENCE SPEC:\n${reference_spec}\n\nSPEC FILE (${spec_file}):\n${spec_content}"
 if [[ -n "$diff_content" ]]; then
   user_message+="\n\nGIT DIFF:\n${diff_content}"
 fi
 
-result=""
-if [[ "$provider" == "openai" ]]; then
+call_openai() {
+  local payload response
   payload=$(jq -n --arg sys "$system_prompt" --arg msg "$user_message" '{model:"gpt-4-turbo",messages:[{"role":"system","content":$sys},{"role":"user","content":$msg}],temperature:0}')
   response=$(curl -sS https://api.openai.com/v1/chat/completions \
     -H "Authorization: Bearer $api_key" \
     -H "Content-Type: application/json" \
     -d "$payload")
-  result=$(echo "$response" | jq -r '.choices[0].message.content // empty')
-  if [[ -z "$result" ]]; then
-    echo "Model API error:" >&2
-    echo "$response" | jq -r '.error.message? // .error // .' >&2
-    exit 1
-  fi
-else
+  echo "$response" | jq -r '.choices[0].message.content // empty'
+}
+
+call_anthropic() {
+  local payload response
   payload=$(jq -n --arg sys "$system_prompt" --arg msg "$user_message" '{model:"claude-3-opus-20240229",system:$sys,messages:[{"role":"user","content":$msg}],max_tokens:1024,temperature:0}')
   response=$(curl -sS https://api.anthropic.com/v1/messages \
     -H "x-api-key: $api_key" \
     -H "anthropic-version: 2023-06-01" \
     -H "Content-Type: application/json" \
     -d "$payload")
-  result=$(echo "$response" | jq -r '.content[0].text // empty')
-  if [[ -z "$result" ]]; then
-    echo "Model API error:" >&2
-    echo "$response" | jq -r '.error.message? // .error // .' >&2
-    exit 1
-  fi
+  echo "$response" | jq -r '.content[0].text // empty'
+}
+
+result=""
+if [[ "$provider" == "openai" ]]; then
+  result=$(call_openai)
+else
+  result=$(call_anthropic)
+fi
+
+if [[ -z "$result" ]]; then
+  echo "Model API error" >&2
+  exit 1
 fi
 
 if [[ "$json" -eq 1 ]]; then
   echo "$result"
-else
-  echo "[VALIDATION] $spec_file"
-  if echo "$result" | jq . >/dev/null 2>&1; then
-    status=$(echo "$result" | jq -r '.status')
-    echo "Status: $status"
-    failures=$(echo "$result" | jq -r '.failures[]? | "- Line " + (.line|tostring) + ": " + .message')
-    warnings=$(echo "$result" | jq -r '.warnings[]? | "- Line " + (.line|tostring) + ": " + .message')
-    suggestions=$(echo "$result" | jq -r '.suggestions[]? | "- [" + .level + "] " + .text')
-    if [[ -n "$failures" ]]; then
-      echo
-      echo "Failures (requires human review):"
-      echo "$failures"
-    fi
-    if [[ -n "$warnings" ]]; then
-      echo
-      echo "Warnings (agent-fixable):"
-      echo "$warnings"
-    fi
-    if [[ -n "$suggestions" ]]; then
-      echo
-      echo "Suggestions:"
-      echo "$suggestions"
-    fi
-    summary=$(echo "$result" | jq -r '.summary | "PASS: " + (.pass|tostring) + " | WARN: " + (.warn|tostring) + " | FAIL: " + (.fail|tostring)')
-    echo
-    echo "Summary:"
-    echo "$summary"
-  else
-    # If result is not valid JSON, just print raw
-    echo "$result"
-  fi
+  exit
 fi
+
+echo "[VALIDATION] $spec_file"
+if echo "$result" | jq . >/dev/null 2>&1; then
+  status=$(echo "$result" | jq -r '.status')
+  echo "Status: $status"
+  failures=$(echo "$result" | jq -r '.failures[]? | "- Line \(.line): \(.message)"')
+  warnings=$(echo "$result" | jq -r '.warnings[]? | "- Line \(.line): \(.message)"')
+  suggestions=$(echo "$result" | jq -r '.suggestions[]? | "- [\(.level)] \(.text)"')
+  if [[ -n "$failures" ]]; then
+    echo
+    echo "Failures (requires human review):"
+    echo "$failures"
+  fi
+  if [[ -n "$warnings" ]]; then
+    echo
+    echo "Warnings (agent-fixable):"
+    echo "$warnings"
+  fi
+  if [[ -n "$suggestions" ]]; then
+    echo
+    echo "Suggestions:"
+    echo "$suggestions"
+  fi
+  summary=$(echo "$result" | jq -r '.summary | "PASS: \(.pass) | WARN: \(.warn) | FAIL: \(.fail)"')
+  echo
+  echo "Summary:"
+  echo "$summary"
+else
+  echo "$result"
+fi
+


### PR DESCRIPTION
## Summary
- overhaul `scripts/spec-validate.sh` implementation
- remove old script logic

## Testing
- `bash -n scripts/spec-validate.sh`
- `scripts/spec-validate.sh --help`
- `scripts/spec-validate.sh specs/spec-validator.md 2>&1 | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_68770b428630832197f416c677271ad5