### PR TITLE
Remove wrapper script and embed validator prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,13 @@ This repository contains:
 
 - **specs/** – reference specifications defining validator behavior
 - **scripts/spec-validate.sh** – Bash CLI that sends specs to an LLM for checks
-- **bin/spec-validator** – convenience wrapper for the CLI
 
 ## Usage
 
 Set `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` and run:
 
 ```bash
-./bin/spec-validator path/to/spec.md
+./scripts/spec-validate.sh path/to/spec.md
 ```
 
 Use `--json` for JSON output or `--diff <file|->` to pass a git diff.
@@ -23,6 +22,6 @@ Use `--json` for JSON output or `--diff <file|->` to pass a git diff.
 ## Example
 
 ```bash
-git diff HEAD~1 -- specs/ | ./bin/spec-validator --diff - specs/spec-validator.md
+git diff HEAD~1 -- specs/ | ./scripts/spec-validate.sh --diff - specs/spec-validator.md
 ```
 

--- a/bin/spec-validator
+++ b/bin/spec-validator
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-SCRIPT_DIR="$(dirname "$(realpath "$0")")"
-"$SCRIPT_DIR/../scripts/spec-validate.sh" "$@"

--- a/promptTemplate-GPT.sh
+++ b/promptTemplate-GPT.sh
@@ -1,5 +1,0 @@
-# Prints system prompt for Spec Validator
-cat <<'TPL'
-You are a Spec Validator. Validate the provided specification against the official Spec Validator specification. Respond in JSON with PASS, WARN, or FAIL status along with recommendations. Use the following format:
-{"status":"PASS|WARN|FAIL","summary":{"pass":0,"warn":0,"fail":0},"failures":[],"warnings":[],"suggestions":[]}
-TPL

--- a/scripts/spec-validate.sh
+++ b/scripts/spec-validate.sh
@@ -90,7 +90,10 @@ else
   diff_content=""
 fi
 
-system_prompt="$(bash "$(dirname "$0")/../promptTemplate-GPT.sh")"
+read -r -d '' system_prompt <<'EOF'
+You are a Spec Validator. Validate the provided specification against the official Spec Validator specification. Respond in JSON with PASS, WARN, or FAIL status along with recommendations. Use the following format:
+{"status":"PASS|WARN|FAIL","summary":{"pass":0,"warn":0,"fail":0},"failures":[],"warnings":[],"suggestions":[]}
+EOF
 
 user_message="REFERENCE SPEC:\n${reference_spec}\n\nSPEC FILE (${spec_file}):\n${spec_content}"
 if [[ -n "$diff_content" ]]; then

--- a/specs/spec-validator-sh.md
+++ b/specs/spec-validator-sh.md
@@ -1,10 +1,9 @@
 ---
 
-id: spec-validator-bash version: 0.4.1 title: Spec Validator CLI (Bash) status: draft entry\_points:
+id: spec-validator-bash version: 0.4.2 title: Spec Validator CLI (Bash) status: draft entry_points:
 
 * scripts/spec-validate.sh
-* bin/spec-validator
-* run via: `./spec-validate.sh path/to/spec.md`
+* run via: `./scripts/spec-validate.sh path/to/spec.md`
 
 description: > Defines a Bash-based CLI tool that validates a spec file against the core spec-validator logic. Designed for lightweight execution using Claude or OpenAI APIs and basic shell utilities.
 
@@ -31,7 +30,6 @@ Enable fast, local spec validation through a CLI wrapper that leverages remote L
 
   * The spec file itself
   * Git diff (optional)
-  * `promptTemplate-GPT.sh` as system instruction
   * Hardcoded reference spec: `./techman/specs/spec-validator.md`
 
 ## ✅ Success Criteria
@@ -125,8 +123,8 @@ git diff HEAD^ HEAD -- specs/ | ./spec-validate.sh --diff -
 
 ## 🔁 Changelog
 
+* 0.4.2 — Embedded system prompt and removed bin wrapper
 * 0.4.1 — Clarified that diff input must only include spec file changes; stricter filtering of input scope
-* 0.4.0 — Added support for hardcoded reference context and promptTemplate; CLI acts as GPT-facing shim
 * 0.3.0 — Defined output format with error levels, clarified FAIL vs WARN intent
 * 0.2.0 — Added support for `git diff` input and agent usability requirement
 * 0.1.0 — Initial draft


### PR DESCRIPTION
## Summary
- drop `bin/spec-validator` wrapper
- inline system prompt inside `spec-validate.sh`
- document new CLI usage in README
- update spec to v0.4.2 and remove promptTemplate references

## Testing
- `bash -n scripts/spec-validate.sh`
- `shellcheck scripts/spec-validate.sh`

------
https://chatgpt.com/codex/tasks/task_e_68770e3a7df48321a8010547a832935c