### PR TITLE
Update spec-validator spec and rewrite CLI

### DIFF
--- a/bin/spec-validator
+++ b/bin/spec-validator
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+DIR="$(cd "$(dirname "$0")/.." && pwd)"
+exec "$DIR/scripts/spec-validate.sh" "$@"

--- a/scripts/promptTemplate-GPT.sh
+++ b/scripts/promptTemplate-GPT.sh
@@ -1,0 +1,3 @@
+You are a Spec Validator. Validate the provided specification against the official Spec Validator specification. Respond in JSON with PASS, WARN, or FAIL status along with recommendations. Include the model_used field indicating which model evaluated the spec. Format:
+{"status":"PASS|WARN|FAIL","model_used":"","summary":{"pass":0,"warn":0,"fail":0},"failures":[],"warnings":[],"suggestions":[],"clarifying_questions":[]}
+

--- a/specs/spec-validator-sh.md
+++ b/specs/spec-validator-sh.md
@@ -1,11 +1,16 @@
 ---
 
-id: spec-validator-bash version: 0.4.2 title: Spec Validator CLI (Bash) status: draft entry_points:
+id: spec-validator-bash
+version: 0.4.4
+title: Spec Validator CLI (Bash)
+status: draft
+entry_points:
+  • bin/spec-validator
+  • scripts/spec-validate.sh
+  • run via: ./bin/spec-validator path/to/spec.md
 
-* scripts/spec-validate.sh
-* run via: `./scripts/spec-validate.sh path/to/spec.md`
-
-description: > Defines a Bash-based CLI tool that validates a spec file against the core spec-validator logic. Designed for lightweight execution using Claude or OpenAI APIs and basic shell utilities.
+description: >
+Defines a Bash-based CLI tool that validates a spec file against the core spec-validator logic. Designed for lightweight execution using Claude or OpenAI APIs and basic shell utilities.
 
 ---
 
@@ -14,34 +19,31 @@ description: > Defines a Bash-based CLI tool that validates a spec file against 
 Enable fast, local spec validation through a CLI wrapper that leverages remote LLMs and shell parsing. Supports Markdown spec files and produces structured validation output for downstream agents.
 
 ## ⚙️ Functionality
-
-* Accepts `.md` (with frontmatter) and `.yaml` spec files
-* Detects and uses one of:
-
-  * `OPENAI_API_KEY`
-  * `ANTHROPIC_API_KEY`
-* Sends content + `spec-validator.md` to LLM
-* Receives structured `PASS | WARN | FAIL` + recommendations (JSON)
-* Optionally saves to disk or pipes to next tool
-* Accepts `git diff` (via stdin or file) to focus validation scope
-
-  * ⚠️ Only applies validation to diff content **within recognized spec files**
-* Uses local context:
-
-  * The spec file itself
-  * Git diff (optional)
-  * Hardcoded reference spec: `./techman/specs/spec-validator.md`
+  • Accepts .md (with frontmatter) and .yaml spec files
+  • Detects and uses one of:
+  • OPENAI_API_KEY
+  • ANTHROPIC_API_KEY
+  • Sends content + spec-validator.md to LLM
+  • Receives structured PASS | WARN | FAIL + recommendations (JSON)
+  • Optionally saves to disk or pipes to next tool
+  • Accepts git diff (via stdin or file) to focus validation scope
+  • ⚠️ Only applies validation to diff content within recognized spec files
+  • Uses local context:
+  • The spec file itself
+  • Git diff (optional)
+  • promptTemplate-GPT.sh as system instruction
+  • Hardcoded reference spec: ./techman/specs/spec-validator.md
+  • Returns metadata including model_used in output
 
 ## ✅ Success Criteria
-
-* CLI runs without error given valid API key and input file
-* Returns results in JSON or human-readable format
-* Fails gracefully with error output if file is invalid or model API fails
-* Ignores non-spec diffs when parsing `git diff`
-* Agent can use tool by piping staged spec changes:
+  • CLI runs without error given valid API key and input file
+  • Returns results in JSON or human-readable format
+  • Fails gracefully with error output if file is invalid or model API fails
+  • Ignores non-spec diffs when parsing git diff
+  • Agent can use tool by piping staged spec changes:
 
 ```bash
-git diff --cached specs/ | ./spec-validate.sh --diff - > result.json
+git diff --cached specs/ | ./bin/spec-validator --diff - > result.json
 ```
 
 ## 📤 Output Format
@@ -51,6 +53,7 @@ git diff --cached specs/ | ./spec-validate.sh --diff - > result.json
 ```text
 [VALIDATION] path/to/spec.md
 Status: FAIL
+Model Used: claude-4-sonnet
 
 Failures (requires human review):
 - Line 5: Missing `version` field in frontmatter — critical metadata incomplete.
@@ -62,15 +65,19 @@ Suggestions:
 - [FAIL] Add a version field to the frontmatter.
 - [WARN] Clarify "aligned values" with an explicit definition.
 
+Clarifying Questions:
+- What does "aligned values" refer to in your domain? Provide examples.
+
 Summary:
 PASS: 7 | WARN: 1 | FAIL: 1
 ```
 
-### JSON Output (`--json`)
+### JSON Output (--json)
 
 ```json
 {
   "status": "FAIL",
+  "model_used": "claude-4-sonnet",
   "summary": {
     "pass": 7,
     "warn": 1,
@@ -97,34 +104,38 @@ PASS: 7 | WARN: 1 | FAIL: 1
       "level": "WARN",
       "text": "Clarify 'aligned values' with an explicit definition."
     }
+  ],
+  "clarifying_questions": [
+    "What does 'aligned values' refer to in your domain? Provide examples."
   ]
 }
 ```
 
 ## 🔐 Security
-
-* Never logs API keys
-* Accepts input from safe file paths only
+  • Never logs API keys
+  • Accepts input from safe file paths only
 
 ## 🧪 Test Strategy
 
 Manual tests via example specs:
 
 ```bash
-./spec-validate.sh specs/example.md > result.json
+./bin/spec-validator specs/example.md > result.json
 cat result.json | jq
 ```
 
 or with diff input:
 
 ```bash
-git diff HEAD^ HEAD -- specs/ | ./spec-validate.sh --diff -
+git diff HEAD^ HEAD -- specs/ | ./bin/spec-validator --diff -
 ```
 
 ## 🔁 Changelog
-
-* 0.4.2 — Embedded system prompt and removed bin wrapper
-* 0.4.1 — Clarified that diff input must only include spec file changes; stricter filtering of input scope
-* 0.3.0 — Defined output format with error levels, clarified FAIL vs WARN intent
-* 0.2.0 — Added support for `git diff` input and agent usability requirement
-* 0.1.0 — Initial draft
+  • 0.4.4 — Added model_used metadata to outputs; defined preferred LLMs based on real-time evaluation research; standardized bin directory usage
+  • 0.4.3 — Canonicalized bin/ as primary executable directory; updated usage examples
+  • 0.4.2 — Introduced clarifying questions output; added error boundary classification for agentic vs human-resolvable issues
+  • 0.4.1 — Clarified that diff input must only include spec file changes; stricter filtering of input scope
+  • 0.4.0 — Added support for hardcoded reference context and promptTemplate; CLI acts as GPT-facing shim
+  • 0.3.0 — Defined output format with error levels, clarified FAIL vs WARN intent
+  • 0.2.0 — Added support for git diff input and agent usability requirement
+  • 0.1.0 — Initial draft


### PR DESCRIPTION
## Summary
- update spec-validator-sh spec to v0.4.4
- rewrite CLI script following new spec
- add `bin/spec-validator` wrapper
- add prompt template for system instructions

## Testing
- `OPENAI_API_KEY=dummy ./bin/spec-validator specs/spec-validator-sh.md` *(fails: Model API error)*

------
https://chatgpt.com/codex/tasks/task_e_687710900bac8321ae2b7151a023930d